### PR TITLE
Make 에러로 인해 Makefile과 minishell.h 일부 변경/추가 하였습니다.

### DIFF
--- a/Libft/Makefile
+++ b/Libft/Makefile
@@ -62,7 +62,7 @@ $(NAME) : $(OBJS)
 	ar -r $@ $^
 
 %.o: %.c
-	cc $(CFLAGS) $< -o $@ -I libft.h
+	cc $(CFLAGS) $< -o $@ -I.
 
 clean :
 	rm -rf $(OBJS) $(OBJS_BONUS) _BONUS

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(NAME) : $(OBJS)
 	cc $(LDFLAGS) $^ $(LIBS) -o $(NAME)
 
 %.o: %.c
-	cc $(CFLAGS)  $(CPPFLAGS) -c $< -o $@ -I minishell.h -I parse/parse.h
+	cc $(CFLAGS)  $(CPPFLAGS) -c $< -o $@ -I. -I/parse
 
 clean :
 	@$(MAKE) -C ./Libft fclean

--- a/minishell.h
+++ b/minishell.h
@@ -17,6 +17,10 @@
 # include <stdlib.h>
 
 # include <readline/readline.h>
+# include <termios.h>
+# include <unistd.h>
+# include <signal.h>
+
 
 /*
  * token


### PR DESCRIPTION
Makfile의 -I 옵션은 헤더파일명이 아니라 헤더파일의 상위**폴더**명을 적어야 해서
make 시 에러가 났습니다.
이 부분을 수정하였으니 확인 부탁드립니다!