### PR TITLE
Fix: exit시 직전 쉘에 대한 exit_status값을 인자로 반환하도록 수정

### DIFF
--- a/run/builtin/builtin_exit.c
+++ b/run/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: seojepar <seojepar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/07 21:46:18 by seojepar          #+#    #+#             */
-/*   Updated: 2024/07/19 18:18:28 by seojepar         ###   ########.fr       */
+/*   Updated: 2024/07/25 23:07:15 by seojepar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,8 @@ void	builtin_exit(char **argv, char **env, t_pipe *info)
 			exit_code = 255;
 		}
 	}
+	else
+		exit_code = ft_atoi(ft_getenv("?", env));
 	free(*env);
 	*env = ft_strdup("?=0");
 	if (!info->next_pipe_exist && !info->prev_pipe_exist)


### PR DESCRIPTION
[문제]
[minishell] % ./minishell 
[minishell] % fweajio
minishell: fweajio: command not found
[minishell] % exit
[minishell] % echo $?
127

이럴시 원래 0이 나오던 문제를 해결함.